### PR TITLE
Bump arango-rs(0.5 to 0.6) and bb8(0.8 to 0.9) deps version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bb8-arangodb"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Gabor Boros <gabor.brs@gmail.com>"]
 edition = "2021"
 description = "ArangoDB driver for bb8 based on the arangors crate."
@@ -14,11 +14,10 @@ exclude = [".gitignore", ".github/**"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-async-trait = "0.1"
-arangors = { version = "0.5", default-features = false }
-bb8 = "0.8"
+arangors = { version = "0.6", default-features = false }
+bb8 = "0.9"
 
 [dev-dependencies]
-arangors = "0.5"
+arangors = "0.6"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tokio-test = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! ```
 //! use bb8::Pool;
 //! use bb8_arangodb::{ArangoConnectionManager, AuthenticationMethod};
-//! use arangors::uclient::reqwest::ReqwestClient;
+//! use arangors::client::reqwest::ReqwestClient;
 //!
 //! tokio_test::block_on(async {
 //!     let manager = ArangoConnectionManager::<ReqwestClient>::new(
@@ -35,7 +35,7 @@
 //! ```
 //! use bb8::Pool;
 //! use bb8_arangodb::{ArangoConnectionManager, AuthenticationMethod};
-//! use arangors::uclient::reqwest::ReqwestClient;
+//! use arangors::client::reqwest::ReqwestClient;
 //!
 //! tokio_test::block_on(async {
 //!     let manager = ArangoConnectionManager::<ReqwestClient>::new(
@@ -57,7 +57,7 @@
 //! ```no_run
 //! use bb8::Pool;
 //! use bb8_arangodb::{ArangoConnectionManager, AuthenticationMethod};
-//! use arangors::uclient::reqwest::ReqwestClient;
+//! use arangors::client::reqwest::ReqwestClient;
 //!
 //! tokio_test::block_on(async {
 //!     let manager = ArangoConnectionManager::<ReqwestClient>::new(
@@ -78,8 +78,7 @@ use std::marker::PhantomData;
 pub use arangors;
 pub use bb8;
 
-use arangors::{uclient, ClientError, GenericConnection};
-use async_trait::async_trait;
+use arangors::{client, ClientError, GenericConnection};
 
 /// Kind of the authentication method to use when establishing a connection.
 #[derive(Debug)]
@@ -96,13 +95,13 @@ pub enum AuthenticationMethod {
 
 /// A connection manager for ArangoDB.
 #[derive(Debug)]
-pub struct ArangoConnectionManager<C: uclient::ClientExt> {
+pub struct ArangoConnectionManager<C: client::ClientExt> {
     url: String,
     method: AuthenticationMethod,
     phantom: PhantomData<C>,
 }
 
-impl<C: uclient::ClientExt> ArangoConnectionManager<C> {
+impl<C: client::ClientExt> ArangoConnectionManager<C> {
     /// Create a new ArangoConnectionManager..
     pub fn new(url: String, method: AuthenticationMethod) -> Self {
         Self {
@@ -113,8 +112,7 @@ impl<C: uclient::ClientExt> ArangoConnectionManager<C> {
     }
 }
 
-#[async_trait]
-impl<C: uclient::ClientExt + Send + 'static> bb8::ManageConnection for ArangoConnectionManager<C> {
+impl<C: client::ClientExt + Send + 'static> bb8::ManageConnection for ArangoConnectionManager<C> {
     type Connection = GenericConnection<C>;
     type Error = ClientError;
 


### PR DESCRIPTION
## Description

In this PR we have upgraded the `bb8` to `0.9` and `arango-rs` to `0.6`, because we are also using recent version of `bb8-redis` which uses the `bb8` version 0.9, so different versions are conflicting `bb8`.

## Supporting information

_Link to other information about the change, such as, GitHub issues or documentation._

## Dependencies

* _List of the dependencies for this change, otherwise write "N/A"_

## Testing instructions

_Please provide detailed step-by-step instructions for testing this change._

## Other information

_Include other information, such as, which sources and targets are affected._
